### PR TITLE
blocks: use a hex-string instead of a placeholder for binary data

### DIFF
--- a/blocks/main.go
+++ b/blocks/main.go
@@ -134,20 +134,18 @@ type cockroach struct {
 
 func (c *cockroach) write(writerID string, blockNum int64, blockCount int, r *rand.Rand) error {
 	var buf bytes.Buffer
-	args := make([]interface{}, blockCount)
 	_, _ = buf.WriteString(
 		`INSERT INTO blocks (block_id, writer_id, block_num, raw_bytes) VALUES`)
 
 	for i := 0; i < blockCount; i++ {
 		blockID := r.Int63()
-		args[i] = randomBlock(r)
 		if i > 0 {
 			_, _ = buf.WriteString(", ")
 		}
-		fmt.Fprintf(&buf, ` (%d, '%s', %d, $%d)`, blockID, writerID, blockNum+int64(i), i+1)
+		fmt.Fprintf(&buf, ` (%d, '%s', %d, x'%x')`, blockID, writerID, blockNum+int64(i), randomBlock(r))
 	}
 
-	_, err := c.db.Exec(buf.String(), args...)
+	_, err := c.db.Exec(buf.String())
 	return err
 }
 


### PR DESCRIPTION
This improves throughput by 12% by reducing the round-trips to execute a
request. When using placeholders we have to prepare, then
bind+execute. Found when trying to figure out how cassandra and mongo
were executing requests faster than we could parse them (without
executing). This is an effort to make the comparison with
cassandra/mongo as apples-to-apples as possible.

Requires https://github.com/cockroachdb/cockroach/pull/13287