### PR TITLE
YCSB: implement incrementing Zipf distribution generator

### DIFF
--- a/ycsb/main.go
+++ b/ycsb/main.go
@@ -50,28 +50,16 @@ const (
 	fieldLength    = 100 // In characters
 )
 
-// Constants for the Zipfian RNG
-// The following constants use the definitions from [1]:
-//"Quickly Generating Billion-Record Synthetic Databases"
-// by Gray et al, SIGMOD 1994. The values are set to match the values in
-// [2]: https://github.com/brianfrankcooper/YCSB/blob/0a330744c5b6f3b1a49e8988ccf1f6ac748340f5/core/src/main/java/com/yahoo/ycsb/generator/ZipfianGenerator.java
-// The following comment translates the names between the two citations.
 const (
-	// zipfS from [2] = -theta from [1].
-	// zipfS = 0.99 TODO(arjun): Golang doesn't support s <= 1, so set to 1.01
-	// for now. Slight skew in distribution results. In the long run we need to
-	// write our own incrementing Zipfian generator.
-	zipfS = 1.01
-	// zipfV = 1, ensures values are 1 indexed.
-	zipfV = 1
-	// zipfIMax from [2] = N from [1], is incremented with each insert.
+	zipfS    = 0.99
+	zipfIMin = 1
 )
 
 var concurrency = flag.Int("concurrency", 2*runtime.NumCPU(),
 	"Number of concurrent workers sending read/write requests.")
 var workload = flag.String("workload", "B", "workload type. Choose from A-E.")
-var tolerateErrors = flag.Bool("tolerate-errors", true,
-	"Keep running on error. (default true)")
+var tolerateErrors = flag.Bool("tolerate-errors", false,
+	"Keep running on error. (default false)")
 var duration = flag.Duration("duration", 0,
 	"The duration to run. If 0, run forever.")
 var verbose = flag.Bool("v", false, "Print *verbose debug output")
@@ -79,11 +67,11 @@ var drop = flag.Bool("drop", true,
 	"Drop the existing table and recreate it to start from scratch")
 var rateLimit = flag.Uint64("rate-limit", 0,
 	"Maximum number of operations per second per worker. Set to zero for no rate limit")
-var initialLoad = flag.Uint64("initial-load", 1000,
+var initialLoad = flag.Uint64("initial-load", 10000,
 	"Initial number of rows to sequentially insert before beginning Zipfian workload generation")
 
-// 4 hours at 5% writes and 30k ops/s
-var maxWrites = flag.Uint64("max-writes", 4*3600*1500,
+// 7 days at 5% writes and 30k ops/s
+var maxWrites = flag.Uint64("max-writes", 7*24*3600*1500,
 	"Maximum number of writes to perform before halting. This is required for accurately generating keys that are uniformly distributed across the keyspace.")
 
 // ycsbWorker independently issues reads, writes, and scans against the database.
@@ -91,7 +79,7 @@ type ycsbWorker struct {
 	workerID int
 	db       *sql.DB
 	// An RNG used to generate random keys
-	zipfR *rand.Zipf
+	zipfR *ZipfGenerator
 	// An RNG used to generate random strings for the values
 	r             *rand.Rand
 	readFreq      float32
@@ -125,7 +113,7 @@ const (
 	scanOp
 )
 
-func newYcsbWorker(db *sql.DB, id int, workloadFlag string) *ycsbWorker {
+func newYcsbWorker(db *sql.DB, zipfR *ZipfGenerator, id int, workloadFlag string) *ycsbWorker {
 	if *verbose {
 		fmt.Printf("Creating YCSB Worker '%d' running Workload %s\n", id, workloadFlag)
 	}
@@ -158,7 +146,6 @@ func newYcsbWorker(db *sql.DB, id int, workloadFlag string) *ycsbWorker {
 		panic("Workload E (scans) not implemented yet")
 	}
 	r := rand.New(source)
-	zipfR := rand.NewZipf(r, zipfS, zipfV, *maxWrites)
 	return &ycsbWorker{
 		db:            db,
 		workerID:      id,
@@ -186,30 +173,30 @@ func (yw *ycsbWorker) hashKey(key []byte, maxValue uint64) uint64 {
 // Keys are chosen by first drawing from a Zipf distribution and hashing the
 // drawn value, so that not all hot keys are close together.
 // See YCSB paper section 5.3 for a complete description of how keys are chosen.
-func (yw *ycsbWorker) nextReadKey() uint64 {
-	var draw, hashedKey uint64
-	draw = yw.zipfR.Uint64()
+func (yw *ycsbWorker) nextReadKey() (uint64, error) {
+	var hashedKey uint64
+	draw := yw.zipfR.Uint64()
 	buf := make([]byte, 8)
 	binary.PutUvarint(buf, draw)
 	hashedKey = yw.hashKey(buf, *maxWrites)
 	if *verbose {
 		fmt.Printf("reader drew: %d -> %d\n", draw, hashedKey)
 	}
-	return hashedKey
+	return hashedKey, nil
 }
 
-// TODO(arjun): once we have the incrementing Zipf RNG implemented, we can
-// adjust the key selection to the correct distribution. Currently the keys are
-// incorrectly skewed, and don't meet the YCSB specification.
-func (yw *ycsbWorker) nextWriteKey() uint64 {
-	draw := yw.zipfR.Uint64()
+func (yw *ycsbWorker) nextWriteKey() (uint64, error) {
+	key, err := yw.zipfR.IncrementIMax()
+	if err != nil {
+		return key, err
+	}
 	buf := make([]byte, 8)
-	binary.PutUvarint(buf, draw)
+	binary.PutUvarint(buf, key)
 	hashedKey := yw.hashKey(buf, *maxWrites)
 	if *verbose {
-		fmt.Printf("writer drew: %d -> %d\n", draw, hashedKey)
+		fmt.Printf("writer drew: fnv(%d) -> %d\n", key, hashedKey)
 	}
-	return hashedKey
+	return hashedKey, nil
 }
 
 // runLoader inserts n rows in parallel across numWorkers, with
@@ -260,8 +247,12 @@ func (yw *ycsbWorker) runWorker(errCh chan<- error, wg *sync.WaitGroup) {
 			if atomic.LoadUint64(&globalStats[writes]) > *maxWrites {
 				break
 			}
-			key := yw.nextWriteKey()
-			if err := yw.insertRow(key); err != nil {
+			key, err := yw.nextWriteKey()
+			if err != nil {
+				errCh <- err
+				atomic.AddUint64(&yw.stats[writeErrors], 1)
+			}
+			if err = yw.insertRow(key); err != nil {
 				errCh <- err
 				atomic.AddUint64(&yw.stats[writeErrors], 1)
 			}
@@ -314,12 +305,16 @@ func (yw *ycsbWorker) insertRow(key uint64) error {
 }
 
 func (yw *ycsbWorker) readRow() error {
-	key := yw.nextReadKey()
+	key, err := yw.nextReadKey()
+	if err != nil {
+		atomic.AddUint64(&yw.stats[readErrors], 1)
+		return err
+	}
 	readString := fmt.Sprintf("SELECT * FROM usertable WHERE ycsb_key=%d", key)
 	return crdb.ExecuteTx(yw.db, func(tx *sql.Tx) error {
-		res, err := tx.Query(readString)
-		if err != nil {
-			return err
+		res, inErr := tx.Query(readString)
+		if inErr != nil {
+			return inErr
 		}
 		var rowsFound int
 		for res.Next() {
@@ -329,8 +324,8 @@ func (yw *ycsbWorker) readRow() error {
 			fmt.Printf("reader found %d rows for key %d\n",
 				rowsFound, key)
 		}
-		if err := res.Close(); err != nil {
-			return err
+		if inErr := res.Close(); err != nil {
+			return inErr
 		}
 		if rowsFound > 0 {
 			atomic.AddUint64(&yw.stats[nonEmptyReads], 1)
@@ -478,11 +473,16 @@ func main() {
 	lastGlobalStats := make([]uint64, len(globalStats))
 	workers := make([]*ycsbWorker, *concurrency)
 
+	zipfR, err := NewZipfGenerator(zipfIMin, *initialLoad, zipfS, *verbose)
+	if err != nil {
+		panic(err)
+	}
+
 	loadStart := time.Now()
 	var wg sync.WaitGroup
 	for i := range workers {
 		wg.Add(1)
-		workers[i] = newYcsbWorker(db, i, *workload)
+		workers[i] = newYcsbWorker(db, zipfR, i, *workload)
 		go workers[i].runLoader(int(*initialLoad)/len(workers), len(workers), i, &wg)
 	}
 	wg.Wait()

--- a/ycsb/zipfgenerator.go
+++ b/ycsb/zipfgenerator.go
@@ -1,0 +1,166 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Arjun Narayan
+//
+// ZipfGenerator implements the Incrementing Zipfian Random Number Generator from
+// [1]: "Quickly Generating Billion-Record Synthetic Databases"
+// by Gray, Sundaresan, Englert, Baclawski, and Weinberger, SIGMOD 1994.
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ZipfGenerator is a random number generator that generates draws from a Zipf
+// distribution. Unlike rand.Zipf, this generator supports incrementing the
+// imax parameter without performing an expensive recomputation of the
+// underlying hidden parameters, which is a pattern used in [1] for efficiently
+// generating large volumes of Zipf-distributed records for synthetic data.
+// Second, rand.Zipf only supports theta <= 1, we suppose all values of theta.
+type ZipfGenerator struct {
+	// The underlying RNG
+	r         *rand.Rand
+	seed      int64
+	zipfGenMu ZipfGeneratorMu
+	// supplied values
+	theta float64
+	iMin  uint64
+	// internally computed values
+	zetaN, alpha, zeta2 float64
+	verbose             bool
+}
+
+// ZipfGeneratorMu holds variables which must be globally synced.
+type ZipfGeneratorMu struct {
+	mu   sync.Mutex
+	iMax uint64
+	eta  float64
+}
+
+// NewZipfGenerator constructs a new ZipfGenerator with the given parameters.
+// It returns an error if the parameters are outside the accepted range.
+func NewZipfGenerator(iMin, iMax uint64, theta float64, verbose bool) (*ZipfGenerator, error) {
+	//fmt.Println("Debug: NewZipfGenerator")
+	seed := int64(time.Now().UnixNano())
+	src := rand.NewSource(seed)
+	r := rand.New(src)
+
+	if iMin >= iMax {
+		return nil, errors.Errorf("iMin %d <= iMax %d", iMin, iMax)
+	}
+	if theta < 0.0 || theta == 1.0 {
+		return nil, errors.Errorf("0 < theta, and theta != 1")
+	}
+
+	z := ZipfGenerator{
+		r:    r,
+		iMin: iMin,
+		zipfGenMu: ZipfGeneratorMu{
+			iMax: iMax,
+		},
+		theta:   theta,
+		verbose: verbose,
+	}
+	z.zipfGenMu.mu.Lock()
+	defer z.zipfGenMu.mu.Unlock()
+
+	// Compute hidden parameters
+	zeta2, err := computeZetaFromScratch(2, theta)
+	if err != nil {
+		return nil, errors.Errorf("Could not compute zeta(2,theta): %s", err)
+	}
+	var zetaN float64
+	zetaN, err = computeZetaFromScratch(iMax+1-iMin, theta)
+	if err != nil {
+		return nil, errors.Errorf("Could not compute zeta(2,%d): %s", iMax, err)
+	}
+	z.alpha = 1.0 / (1.0 - theta)
+	z.zipfGenMu.eta = (1 - math.Pow(2.0/float64(z.zipfGenMu.iMax+1-z.iMin), 1.0-theta)) / (1.0 - zeta2/zetaN)
+	z.zeta2 = zeta2
+	z.zetaN = zetaN
+	return &z, nil
+}
+
+// computeZetaIncrementally recomputes zeta(iMax, theta), assuming that
+// sum = zeta(oldIMax, theta). It returns zeta(iMax, theta), computed incrementally.
+func computeZetaIncrementally(oldIMax, iMax uint64, theta float64, sum float64) (float64, error) {
+	//fmt.Println("Debug: computeZetaIncrementally")
+	if iMax < oldIMax {
+		return 0, errors.Errorf("Can't increment iMax backwards!")
+	}
+	for i := oldIMax + 1; i <= iMax; i++ {
+		sum += 1.0 / math.Pow(float64(i), theta)
+	}
+	return sum, nil
+}
+
+// The function zeta computes the value
+// zeta(n, theta) = (1/1)^theta + (1/2)^theta + (1/3)^theta + ... + (1/n)^theta
+func computeZetaFromScratch(n uint64, theta float64) (float64, error) {
+	zeta, err := computeZetaIncrementally(0, n, theta, 0.0)
+	if err != nil {
+		return zeta, errors.Errorf("could not compute zeta: %s", err)
+	}
+	return zeta, nil
+}
+
+// Uint64 draws a new value between iMin and iMax, with probabilities
+// according to the Zipf distribution.
+func (z *ZipfGenerator) Uint64() uint64 {
+	u := z.r.Float64()
+	uz := u * z.zetaN
+	if uz < 1.0 {
+		return z.iMin
+	} else if uz < 1.0+math.Pow(0.5, z.theta) {
+		return z.iMin + 1
+	}
+
+	z.zipfGenMu.mu.Lock()
+	spread := float64(z.zipfGenMu.iMax + 1 - z.iMin)
+	result := z.iMin + uint64(spread*math.Pow(z.zipfGenMu.eta*u-z.zipfGenMu.eta+1.0, z.alpha))
+	if z.verbose {
+		fmt.Printf("Uint64[%d, %d] -> %d\n", z.iMin, z.zipfGenMu.iMax, result)
+	}
+	z.zipfGenMu.mu.Unlock()
+	return result
+}
+
+// IncrementIMax increments, iMax, recomputing the internal values that depend
+// on it, and returns the value of iMax before it was incremented. It throws an
+// error if it could not increment iMax.
+func (z *ZipfGenerator) IncrementIMax() (uint64, error) {
+	z.zipfGenMu.mu.Lock()
+	oldIMax := z.zipfGenMu.iMax
+	zetaN, err := computeZetaIncrementally(z.zipfGenMu.iMax, z.zipfGenMu.iMax+1, z.theta, z.zetaN)
+	if err != nil {
+		z.zipfGenMu.mu.Unlock()
+		return 0, errors.Errorf("Could not incrementally compute zeta: %s", err)
+	}
+	eta := (1 - math.Pow(2.0/float64(z.zipfGenMu.iMax+1-z.iMin), 1.0-z.theta)) / (1.0 - z.zeta2/zetaN)
+	z.zipfGenMu.eta = eta
+	z.zetaN = zetaN
+	z.zipfGenMu.iMax++
+	z.zipfGenMu.mu.Unlock()
+
+	return oldIMax, nil
+}

--- a/ycsb/zipfgenerator_test.go
+++ b/ycsb/zipfgenerator_test.go
@@ -1,0 +1,158 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+//
+// Author: Arjun Narayan
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"testing"
+)
+
+type params struct {
+	iMin, iMax uint64
+	theta      float64
+}
+
+var gens = []params{
+	{0, 100, 0.99},
+	{0, 100, 1.01},
+}
+
+func TestCreateZipfGenerator(t *testing.T) {
+	for _, gen := range gens {
+		_, err := NewZipfGenerator(gen.iMin, gen.iMax, gen.theta, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+var zetas = [][]float64{
+	// n, theta, zeta(n,theta)
+	{20.0, 0.99, 3.64309060779367},
+	{200.0, 0.99, 6.02031118558},
+	{1000, 0.99, 7.72895321728},
+	{2000, 0.99, 8.47398788329},
+	{10000, 0.99, 10.2243614596},
+	{100000, 0.99, 12.7783380626},
+	{1000000, 0.99, 15.391849746},
+	{10000000, 0.99, 18.066242575},
+	{100000000, 0.99, 20.80293049},
+}
+
+func TestZetaFromScratch(t *testing.T) {
+	for _, zeta := range zetas {
+		computedZeta, err := computeZetaFromScratch(uint64(zeta[0]), zeta[1])
+		if err != nil {
+			t.Fatalf("Failed to compute zeta(%d,%f): %s", uint64(zeta[0]), zeta[1], err)
+		}
+		if math.Abs(computedZeta-zeta[2]) > 0.000000001 {
+			t.Fatalf("expected %6.4f, got %6.4f", zeta[2], computedZeta)
+		}
+	}
+}
+
+func TestZetaIncrementally(t *testing.T) {
+	// Theta cannot be 1 by definition, so this is a safe initial value.
+	oldTheta := 1.0
+	for i, zeta := range zetas {
+		var oldZetaN float64
+		var oldN uint64
+		// If theta has changed, recompute from scratch
+		if zetas[i][0] != oldTheta {
+			var err error
+			oldZetaN, err = computeZetaFromScratch(uint64(zeta[0]), zeta[1])
+			if err != nil {
+				t.Fatalf("Failed to compute zeta(%d,%f): %s", uint64(zeta[0]), zeta[1], err)
+			}
+			oldN = uint64(zeta[0])
+			continue
+		}
+
+		computedZeta, err := computeZetaIncrementally(oldN, uint64(zeta[0]), zeta[1], oldZetaN)
+		if err != nil {
+			t.Fatalf("Failed to compute zeta(%d,%f) incrementally: %s", uint64(zeta[0]), zeta[1], err)
+		}
+		if math.Abs(computedZeta-zeta[2]) > 0.000000001 {
+			t.Fatalf("expected %6.4f, got %6.4f", zeta[2], computedZeta)
+		}
+
+		oldZetaN = computedZeta
+		oldN = uint64(zeta[0])
+	}
+}
+
+func runZipfGenerators(t *testing.T, withIncrements bool) {
+	gen := gens[0]
+	z, err := NewZipfGenerator(gen.iMin, gen.iMax, gen.theta, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const ROLLS = 10000
+	x := make([]int, ROLLS)
+
+	for i := 0; i < ROLLS; i++ {
+		x[i] = int(z.Uint64())
+		z.zipfGenMu.mu.Lock()
+		if x[i] < int(z.iMin) || x[i] > int(z.zipfGenMu.iMax) {
+			t.Fatalf("zipf(%d,%d,%f) rolled %d at index %d and seed %d", z.iMin, z.zipfGenMu.iMax, z.theta, x[i], i, z.seed)
+			z.zipfGenMu.mu.Unlock()
+			if withIncrements {
+				if _, err := z.IncrementIMax(); err != nil {
+					t.Fatalf("could not increment iMax: %s", err)
+				}
+			}
+		}
+		z.zipfGenMu.mu.Unlock()
+	}
+
+	if withIncrements {
+		return
+	}
+
+	sort.Ints(x)
+
+	max := x[ROLLS-1]
+	step := max / 20
+	index := 0
+	count := 0
+	for i := 0; i < max; i += step {
+		count = 0
+		for {
+			if x[index] >= i {
+				break
+			}
+			index++
+			count++
+		}
+		fmt.Printf("[%10d-%10d)        ", i, i+step)
+		for j := 0; j < count; j++ {
+			if j%50 == 0 {
+				fmt.Printf("%c", '∎')
+			}
+		}
+		fmt.Println()
+	}
+}
+
+func TestZipfGenerator(t *testing.T) {
+	runZipfGenerators(t, false)
+	runZipfGenerators(t, true)
+}

--- a/ycsb/zipfgenerator_test.go
+++ b/ycsb/zipfgenerator_test.go
@@ -115,7 +115,7 @@ func runZipfGenerators(t *testing.T, withIncrements bool) {
 			t.Fatalf("zipf(%d,%d,%f) rolled %d at index %d and seed %d", z.iMin, z.zipfGenMu.iMax, z.theta, x[i], i, z.seed)
 			z.zipfGenMu.mu.Unlock()
 			if withIncrements {
-				if _, err := z.IncrementIMax(); err != nil {
+				if err := z.IncrementIMax(); err != nil {
 					t.Fatalf("could not increment iMax: %s", err)
 				}
 			}


### PR DESCRIPTION
This is a work in progress, I'm mostly interested in a review that checks if `zipfgenerator.go` correctly implements the algorithm from Page 24 of "Quickly Generating Billion-Record Synthetic Databases" (https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/syntheticdatagen.pdf). Actually integrating it properly into `main.go` is not yet complete.

There are some tests that help ensure some invariants, and that print out helpful distributions.

- [x] Implement the incrementing Zipf distribution random number generator
as specified by Gray et al (SIGMOD 1994). Use it in the key
generation step in the YCSB load generator.
- [x] Changing the YCSB load generator to use the incrementing
Zipf RNG.
- [x] verifying via a test that there are no read or write errors
(due to writing to a key that already has been written to, or reading
from a key that has not yet been written to) that result from running
the incrementing zipf generator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/loadgen/14)
<!-- Reviewable:end -->
