### PR TITLE
kv: remove unnecessary LIMIT

### DIFF
--- a/kv/main.go
+++ b/kv/main.go
@@ -284,7 +284,7 @@ func setupCockroach(parsedURL *url.URL) (database, error) {
 		}
 	}
 
-	readStmt, err := db.Prepare(`SELECT k, v FROM test.kv WHERE k = $1 LIMIT 1`)
+	readStmt, err := db.Prepare(`SELECT k, v FROM test.kv WHERE k = $1`)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We're selecting on the primary key, so there will always be at most one
result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/loadgen/28)
<!-- Reviewable:end -->
