### PR TITLE
kv: fix SPLIT AT key computation

### DIFF
--- a/kv/main.go
+++ b/kv/main.go
@@ -277,8 +277,9 @@ func setupCockroach(parsedURL *url.URL) (database, error) {
 
 	if *splits > 0 {
 		r := rand.New(rand.NewSource(int64(time.Now().UnixNano())))
+		g := newGenerator(&sequence{val: *writeSeq, seed: *seqSeed})
 		for i := 0; i < *splits; i++ {
-			if _, err := db.Exec(`ALTER TABLE test.kv SPLIT AT ($1)`, r.Int63()); err != nil {
+			if _, err := db.Exec(`ALTER TABLE test.kv SPLIT AT ($1)`, g.hash(r.Int63())); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
Need to pass the random int through the hasher in order to get the same
key range as is used for read and write keys. In particular,
rand.Int63() returns only non-negative values while
generator.{read,write}Key use the full int64 range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/loadgen/29)
<!-- Reviewable:end -->
