### PR TITLE
ycsb: fix --initial-load

### DIFF
--- a/ycsb/zipfgenerator.go
+++ b/ycsb/zipfgenerator.go
@@ -66,8 +66,8 @@ func NewZipfGenerator(iMin, iMax uint64, theta float64, verbose bool) (*ZipfGene
 	src := rand.NewSource(seed)
 	r := rand.New(src)
 
-	if iMin >= iMax {
-		return nil, errors.Errorf("iMin %d <= iMax %d", iMin, iMax)
+	if iMin > iMax {
+		return nil, errors.Errorf("iMin %d > iMax %d", iMin, iMax)
 	}
 	if theta < 0.0 || theta == 1.0 {
 		return nil, errors.Errorf("0 < theta, and theta != 1")


### PR DESCRIPTION
Fix ycsbWorker.runLoader so that it actually loads all of the keys
specified. The previous code was dividing two integers which resulted in
precision loss if the values didn't divide evenly. Additionally, there
was an off-by-one error in the calculation of the first key to add
because zipfIMin is set to 1, not 0.

Relax the restriction that IMin must be less than IMax. It can be equal
as well without problem. This allows --initial-load=1 to
work (i.e. write a single key).

Together, these changes allow `--initial-load=1 --workload=C` to
generate a 100% read workload to a single key for any concurrency
setting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/loadgen/30)
<!-- Reviewable:end -->
