### PR TITLE
ycsb: fix ycsb test failure

### DIFF
--- a/ycsb/zipfgenerator_test.go
+++ b/ycsb/zipfgenerator_test.go
@@ -112,7 +112,7 @@ func runZipfGenerators(t *testing.T, withIncrements bool) {
 		x[i] = int(z.Uint64())
 		z.zipfGenMu.mu.Lock()
 		if x[i] < int(z.iMin) || x[i] > int(z.zipfGenMu.iMax) {
-			t.Fatalf("zipf(%d,%d,%f) rolled %d at index %d and seed %d", z.iMin, z.zipfGenMu.iMax, z.theta, x[i], i, z.seed)
+			t.Fatalf("zipf(%d,%d,%f) rolled %d at index %d", z.iMin, z.zipfGenMu.iMax, z.theta, x[i], i)
 			z.zipfGenMu.mu.Unlock()
 			if withIncrements {
 				if err := z.IncrementIMax(); err != nil {


### PR DESCRIPTION
Seed as a variable was removed in #31, but not from this test, breaking the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/loadgen/35)
<!-- Reviewable:end -->
