### PR TITLE
kv: Add basic Dockerfile used to create kv docker image for demos

### DIFF
--- a/kv/Dockerfile
+++ b/kv/Dockerfile
@@ -1,0 +1,12 @@
+# Build the docker image only after building the kv binary with:
+#   CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo .
+# This builds a minimal image that even lacks root CA certs, but that's
+# fine for most uses since our instructions for securely deploying
+# CockroachDB involve creating a new CA cert that has to be distributed
+# to clients anyways.
+from scratch
+
+MAINTAINER Alex Robinson <alex@cockroachlabs.com>
+
+ADD kv /kv
+ENTRYPOINT ["/kv"]


### PR DESCRIPTION
I'm not sure this really even justifies being added to the repo, but thought I should at least send it out since it was how I built https://hub.docker.com/r/cockroachdb/loadgen-kv/

@tamird

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/loadgen/46)
<!-- Reviewable:end -->
