### PR TITLE
tpch: explicitly disable distsql mode

### DIFF
--- a/tpch/queries.go
+++ b/tpch/queries.go
@@ -48,7 +48,7 @@ var queryStmts = [...]string{
 }
 
 func runQuery(db *sql.DB, query int) (int, error) {
-	var queryString string
+	queryString := "SET DISTSQL = 'off'; "
 	if *distsql {
 		queryString = "SET DISTSQL = 'always'; "
 	}


### PR DESCRIPTION
This is necessary when running against a node with distsql enabled by
default. Previously `./tpch -dist-sql=false ...` would run with distsql
enabled in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/loadgen/47)
<!-- Reviewable:end -->
