### PR TITLE
kv,ycsb: SCATTER replicas after splitting

### DIFF
--- a/kv/main.go
+++ b/kv/main.go
@@ -336,6 +336,10 @@ func setupCockroach(parsedURL *url.URL) (database, error) {
 				return nil, err
 			}
 		}
+
+		if _, err := db.Exec(`ALTER TABLE test.kv SCATTER`); err != nil {
+			return nil, err
+		}
 	}
 
 	readStmt, err := db.Prepare(`SELECT k, v FROM test.kv WHERE k = $1`)

--- a/ycsb/main.go
+++ b/ycsb/main.go
@@ -428,6 +428,10 @@ CREATE TABLE IF NOT EXISTS ycsb.usertable (
 				log.Fatal(err)
 			}
 		}
+
+		if _, err := db.Exec(`ALTER TABLE ycsb.usertable SCATTER`); err != nil {
+			return nil, err
+		}
 	}
 
 	return &cockroach{db: db}, nil


### PR DESCRIPTION
Scatter replicas after splitting to ensure more even range balance in
short duration tests. Under log duration, the cluster will achieve
balance automatically, but currently it throttles rebalancing to avoid
thrashing.