### PR TITLE
tpcc: set isolation level to serializable in txns

### DIFF
--- a/tpcc/delivery.go
+++ b/tpcc/delivery.go
@@ -51,7 +51,7 @@ func (del delivery) run(db *sql.DB, wID int) (interface{}, error) {
 	if err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&sql.TxOptions{},
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
 		func(tx *sql.Tx) error {
 			getNewOrder, err := tx.Prepare(`
 			SELECT no_o_id

--- a/tpcc/new_order.go
+++ b/tpcc/new_order.go
@@ -121,7 +121,7 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 	err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&sql.TxOptions{},
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
 		func(tx *sql.Tx) error {
 			// Select the warehouse tax rate.
 			if err := tx.QueryRow(

--- a/tpcc/order_status.go
+++ b/tpcc/order_status.go
@@ -77,7 +77,7 @@ func (o orderStatus) run(db *sql.DB, wID int) (interface{}, error) {
 	if err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&sql.TxOptions{},
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
 		func(tx *sql.Tx) error {
 			// 2.6.2.2 explains this entire transaction.
 

--- a/tpcc/payment.go
+++ b/tpcc/payment.go
@@ -110,7 +110,7 @@ func (p payment) run(db *sql.DB, wID int) (interface{}, error) {
 	if err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&sql.TxOptions{},
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
 		func(tx *sql.Tx) error {
 			var wName, dName string
 			// Update warehouse with payment

--- a/tpcc/stock_level.go
+++ b/tpcc/stock_level.go
@@ -60,7 +60,7 @@ func (s stockLevel) run(db *sql.DB, wID int) (interface{}, error) {
 	if err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&sql.TxOptions{},
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
 		func(tx *sql.Tx) error {
 			var dNextOID int
 			if err := tx.QueryRow(`


### PR DESCRIPTION
This commit adds support for explicitly setting the isolation level. Doing this work revealed that Cockroach doesn't actually support this syntax (although this syntax really is to ensure serializability in Postgres so that we are comparing apples to apples), so this isn't ready for merging until that is fixed.
