### PR TITLE
build: mount bin as a tempdir

### DIFF
--- a/teamcity-test.sh
+++ b/teamcity-test.sh
@@ -6,5 +6,6 @@ docker run \
     --workdir=/go/src/github.com/cockroachdb/loadgen \
     --volume="${GOPATH%%:*}/src":/go/src \
     --volume="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)":/go/src/github.com/cockroachdb/loadgen \
+    --volume="/tmp/loadgenbin":/go/src/github.com/cockroachdb/loadgen/bin \
     --rm \
     cockroachdb/builder:20170422-212842 make all | go-test-teamcity


### PR DESCRIPTION
To prevent agent pollution.