### PR TITLE
tpcc: index hints and direction improvements

### DIFF
--- a/tpcc/ddls.go
+++ b/tpcc/ddls.go
@@ -97,7 +97,7 @@ create table "order" (
   o_carrier_id integer,
   o_ol_cnt     integer,
   o_all_local  integer,
-  primary key (o_w_id, o_d_id, o_id),
+  primary key (o_w_id, o_d_id, o_id DESC),
   foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id)
 )`,
 
@@ -166,7 +166,7 @@ create table order_line (
   ol_quantity     integer,
   ol_amount       decimal(6,2),
   ol_dist_info    char(24),
-  primary key (ol_w_id, ol_d_id, ol_o_id, ol_number),
+  primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number),
   foreign key (ol_w_id, ol_d_id, ol_o_id) references "order" (o_w_id, o_d_id, o_id),
   foreign key (ol_supply_w_id, ol_i_id) references stock (s_w_id, s_i_id)
 )`,

--- a/tpcc/order_status.go
+++ b/tpcc/order_status.go
@@ -96,7 +96,7 @@ func (o orderStatus) run(db *sql.DB, wID int) (interface{}, error) {
 				// Case 2: Pick the middle row, rounded up, from the selection by last name.
 				rows, err := tx.Query(`
 					SELECT c_id, c_balance, c_first, c_middle
-					FROM customer
+					FROM customer@customer_idx
 					WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
 					ORDER BY c_first ASC`,
 					wID, d.dID, d.cLast)

--- a/tpcc/payment.go
+++ b/tpcc/payment.go
@@ -141,7 +141,7 @@ func (p payment) run(db *sql.DB, wID int) (interface{}, error) {
 				// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
 				rows, err := tx.Query(`
 					SELECT c_id
-					FROM customer
+					FROM customer@customer_idx
 					WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
 					ORDER BY c_first ASC`,
 					wID, d.dID, d.cLast)


### PR DESCRIPTION
We should use a descending index on order.o_id, since we always use that
key component in a reverse scan. This improves performance by a lot.

Also, hint that the customer_idx index should be used when looking up by
last name. It's not clear why the optimizer didn't notice this by
itself. Presumably it thought the cost of the index join was too high.