### PR TITLE
tpcc: loading improvements

### DIFF
--- a/tpcc/ddls.go
+++ b/tpcc/ddls.go
@@ -233,7 +233,11 @@ create table order_line (
 
 // loadSchema loads the entire TPCC schema into the database.
 func loadSchema(db *sql.DB, interleave bool, index bool) {
-	for _, stmt := range ddls {
+	schemaType := "tables"
+	if index {
+		schemaType = "indexes"
+	}
+	for i, stmt := range ddls {
 		sql := stmt.ddl
 		if index != stmt.index {
 			continue
@@ -244,5 +248,7 @@ func loadSchema(db *sql.DB, interleave bool, index bool) {
 		if _, err := db.Exec(sql); err != nil {
 			panic(fmt.Sprintf("Couldn't exec %s: %s\n", sql, err))
 		}
+		fmt.Printf("Created %d %s\r", i+1, schemaType)
 	}
+	fmt.Printf("\n")
 }

--- a/tpcc/generate.go
+++ b/tpcc/generate.go
@@ -18,7 +18,10 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"math/rand"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -52,67 +55,54 @@ func prepare(db *sql.DB, query string) *sql.Stmt {
 	return stmt
 }
 
-func parallelLoad(n int, entityName string, loader func(int)) {
+func parallelLoad(n int, batchSize int, entityName string, loader func(int, int)) {
+	if n%batchSize != 0 {
+		log.Fatalf("invalid batch size doesn't divide n: %d %d", batchSize, n)
+	}
 	var wg sync.WaitGroup
-	ch := make(chan int)
+	ch := make(chan int, n/batchSize)
+	for id := 0; id < n/batchSize; id++ {
+		ch <- id
+	}
+	close(ch)
+
+	outCh := make(chan int, 1000)
+	start := time.Now()
 	for i := 0; i < *concurrency; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for id := range ch {
-				loader(id)
+				loader(id*batchSize+1, batchSize)
+				outCh <- id
 			}
 		}()
 	}
 
-	for id := 1; id <= n; id++ {
-		ch <- id
-		if id%1000 == 0 {
-			fmt.Printf("Loaded %d/%d %ss\n", id, n, entityName)
-		}
+	go func() {
+		wg.Wait()
+		close(outCh)
+	}()
+
+	i := 1
+	for range outCh {
+		fmt.Printf("Loaded %d/%d %ss\n", i*batchSize, n, entityName)
+		i++
 	}
-	close(ch)
-	wg.Wait()
+	elapsed := time.Since(start)
+	fmt.Printf("%s\t%8d\t%12.1f ns/op\n",
+		"TPCCLoad"+strings.Title(entityName), n, float64(elapsed.Nanoseconds())/float64(n))
 }
 
 func generateData(db *sql.DB) {
-	stmtItem := prepare(db, `
-INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data)
-VALUES ($1, $2, $3, $4, $5)`)
 	stmtWarehouse := prepare(db, `
 INSERT INTO warehouse (w_id, w_name, w_street_1, w_street_2, w_city, w_state, w_zip, w_tax, w_ytd)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`)
-	stmtStock := prepare(db, `
-INSERT INTO stock (
-	s_i_id, s_w_id, s_quantity,
-	s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10,
-	s_ytd, s_order_cnt, s_remote_cnt, s_data)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`)
 	stmtDistrict := prepare(db, `
 INSERT INTO district (
 	d_id, d_w_id, d_name, d_street_1, d_street_2,
 	d_city, d_state, d_zip, d_tax, d_ytd, d_next_o_id)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`)
-	stmtCustomer := prepare(db, `
-INSERT INTO customer (
-	c_id, c_d_id, c_w_id, c_first, c_middle, c_last,
-	c_street_1, c_street_2, c_city, c_state, c_zip,
-	c_phone, c_since, c_credit, c_credit_lim, c_discount,
-	c_balance, c_ytd_payment, c_payment_cnt,
-	c_delivery_cnt, c_data)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)`)
-	stmtHistory := prepare(db, `
-INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`)
-	stmtOrder := prepare(db, `
-INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`)
-	stmtOrderLine := prepare(db, `
-INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`)
-	stmtNewOrder := prepare(db, `
-INSERT INTO new_order (no_o_id, no_d_id, no_w_id)
-VALUES ($1, $2, $3)`)
 
 	// See section 1.3 for the general layout of the tables.
 	// See section 4.3 for the rules on how to populate the database.
@@ -120,19 +110,27 @@ VALUES ($1, $2, $3)`)
 	fmt.Println("Loading items...")
 
 	// 100,000 items.
-	// TODO(jordan): send these inserts in batches.
-	parallelLoad(nItems, "item", func(id int) {
-		if _, err := stmtItem.Exec(id,
-			randInt(1, 10000),                         // im_id: "Image ID associated to Item"
-			randAString(14, 24),                       // name
-			float64(randInt(100, 10000))/float64(100), // price
-			randOriginalString(),
-		); err != nil {
+	parallelLoad(nItems, 1000, "item", func(id int, batchSize int) {
+		stmtStr := "INSERT INTO item (i_id, i_im_id, i_name, i_price, i_data) VALUES "
+		for i := id; i < id+batchSize; i++ {
+			if i != id {
+				stmtStr += ","
+			}
+			stmtStr += fmt.Sprintf("(%d,%d,'%s',%f,'%s')",
+				i,
+				randInt(1, 10000),                         // im_id: "Image ID associated to Item"
+				randAString(14, 24),                       // name
+				float64(randInt(100, 10000))/float64(100), // price
+				randOriginalString(),
+			)
+		}
+		if _, err := db.Exec(stmtStr); err != nil {
 			panic(err)
 		}
 	})
 
 	now := time.Now()
+	nowString := now.Format("2006-01-02 15:04:05")
 	for wID := 0; wID < *warehouses; wID++ {
 		fmt.Printf("Loading warehouse %d...\n", wID)
 		if _, err := stmtWarehouse.Exec(wID,
@@ -148,24 +146,36 @@ VALUES ($1, $2, $3)`)
 		}
 
 		// 100,000 stock per warehouse.
-		parallelLoad(nStock, "stock", func(id int) {
-			if _, err := stmtStock.Exec(id, wID,
-				randInt(10, 100),     // quantity
-				randAString(24, 24),  // dist_01
-				randAString(24, 24),  // dist_02
-				randAString(24, 24),  // dist_03
-				randAString(24, 24),  // dist_04
-				randAString(24, 24),  // dist_05
-				randAString(24, 24),  // dist_06
-				randAString(24, 24),  // dist_07
-				randAString(24, 24),  // dist_08
-				randAString(24, 24),  // dist_09
-				randAString(24, 24),  // dist_10
-				0,                    // ytd
-				0,                    // order_cnt
-				0,                    // remote_cnt
-				randOriginalString(), // data
-			); err != nil {
+		parallelLoad(nStock, 1000, "stock", func(id int, batchSize int) {
+			stmtStr := `INSERT INTO stock (
+	s_i_id, s_w_id, s_quantity,
+	s_dist_01, s_dist_02, s_dist_03, s_dist_04, s_dist_05, s_dist_06, s_dist_07, s_dist_08, s_dist_09, s_dist_10,
+	s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES `
+			for i := id; i < id+batchSize; i++ {
+				if i != id {
+					stmtStr += ","
+				}
+				stmtStr += fmt.Sprintf("(%d,%d,%d,'%s','%s','%s','%s','%s','%s','%s','%s','%s','%s',%d,%d,%d,'%s')",
+					i, wID,
+					randInt(10, 100),     // quantity
+					randAString(24, 24),  // dist_01
+					randAString(24, 24),  // dist_02
+					randAString(24, 24),  // dist_03
+					randAString(24, 24),  // dist_04
+					randAString(24, 24),  // dist_05
+					randAString(24, 24),  // dist_06
+					randAString(24, 24),  // dist_07
+					randAString(24, 24),  // dist_08
+					randAString(24, 24),  // dist_09
+					randAString(24, 24),  // dist_10
+					0,                    // ytd
+					0,                    // order_cnt
+					0,                    // remote_cnt
+					randOriginalString(), // data
+				)
+			}
+
+			if _, err := db.Exec(stmtStr); err != nil {
 				panic(err)
 			}
 		})
@@ -187,47 +197,67 @@ VALUES ($1, $2, $3)`)
 			}
 
 			// 3000 customers per district
-			parallelLoad(nCustomers, "customer", func(cID int) {
-				// 10% of the customer rows have bad credit.
-				// See section 4.3, under the CUSTOMER table population section.
-				credit := goodCredit
-				if rand.Intn(9) == 0 {
-					// Poor 10% :(
-					credit = badCredit
+			parallelLoad(nCustomers, 1000, "customer", func(id int, batchSize int) {
+				stmtStr := `INSERT INTO customer (
+	c_id, c_d_id, c_w_id, c_first, c_middle, c_last,
+	c_street_1, c_street_2, c_city, c_state, c_zip,
+	c_phone, c_since, c_credit, c_credit_lim, c_discount,
+	c_balance, c_ytd_payment, c_payment_cnt,
+	c_delivery_cnt, c_data) VALUES `
+				historyStmtStr := `INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_date, h_amount, h_data)
+VALUES `
+				for cID := id; cID < id+batchSize; cID++ {
+					// 10% of the customer rows have bad credit.
+					// See section 4.3, under the CUSTOMER table population section.
+					credit := goodCredit
+					if rand.Intn(9) == 0 {
+						// Poor 10% :(
+						credit = badCredit
+					}
+					var lastName string
+					// The first 1000 customers get a last name generated according to their id;
+					// the rest get an NURand generated last name.
+					if cID <= 1000 {
+						lastName = randCLastSyllables(cID - 1)
+					} else {
+						lastName = randCLast()
+					}
+
+					if cID != id {
+						stmtStr += ","
+						historyStmtStr += ","
+					}
+					stmtStr += fmt.Sprintf("(%d,%d,%d,'%s','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s',%f,%f,%f,%f,%d,%d,'%s')",
+						cID, dID, wID,
+						randAString(8, 16), // first name
+						middleName,
+						lastName,
+						randAString(10, 20), // street 1
+						randAString(10, 20), // street 2
+						randAString(10, 20), // city name
+						randState(),
+						randZip(),
+						randNString(16, 16), // phone number
+						nowString,
+						credit,
+						creditLimit,
+						float64(randInt(0, 5000))/float64(10000.0), // discount
+						balance,
+						ytdPayment,
+						paymentCount,
+						deliveryCount,
+						randAString(300, 500), // data
+					)
+
+					// 1 history row per customer
+					historyStmtStr += fmt.Sprintf("(%d,%d,%d,%d,%d,'%s',%f,'%s')",
+						cID, dID, wID, dID, wID, nowString, 10.00, randAString(12, 24))
+
 				}
-				var lastName string
-				// The first 1000 customers get a last name generated according to their id;
-				// the rest get an NURand generated last name.
-				if cID <= 1000 {
-					lastName = randCLastSyllables(cID - 1)
-				} else {
-					lastName = randCLast()
-				}
-				if _, err := stmtCustomer.Exec(cID, dID, wID,
-					randAString(8, 16), // first name
-					middleName,
-					lastName,
-					randAString(10, 20), // street 1
-					randAString(10, 20), // street 2
-					randAString(10, 20), // city name
-					randState(),
-					randZip(),
-					randNString(16, 16), // phone number
-					now,
-					credit,
-					creditLimit,
-					float64(randInt(0, 5000))/float64(10000.0), // discount
-					balance,
-					ytdPayment,
-					paymentCount,
-					deliveryCount,
-					randAString(300, 500), // data
-				); err != nil {
+				if _, err := db.Exec(stmtStr); err != nil {
 					panic(err)
 				}
-
-				// 1 history row per customer
-				if _, err := stmtHistory.Exec(cID, dID, wID, dID, wID, time.Now(), 10.00, randAString(12, 24)); err != nil {
+				if _, err := db.Exec(historyStmtStr); err != nil {
 					panic(err)
 				}
 			})
@@ -237,44 +267,68 @@ VALUES ($1, $2, $3)`)
 			for i, cID := range rand.Perm(nCustomers) {
 				randomCIDs[i] = cID + 1
 			}
-			parallelLoad(nCustomers, "order", func(oID int) {
-				olCnt := randInt(5, 15)
-				var carrierID interface{}
-				if oID < 2101 {
-					carrierID = randInt(1, 10)
-				} else {
-					carrierID = sql.NullInt64{Int64: 0, Valid: false}
-				}
-				entryD := time.Now()
-				if _, err := stmtOrder.Exec(oID, dID, wID, randomCIDs[oID-1], entryD, carrierID, olCnt, 1); err != nil {
-					panic(err)
-				}
-
-				for olNumber := 1; olNumber <= olCnt; olNumber++ {
-					var amount float64
-					var deliveryD interface{}
+			parallelLoad(nCustomers, 1000, "order", func(i int, batchSize int) {
+				stmtStr := `INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES `
+				stmtNewOrderStr := `INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES `
+				haveNewOrders := false
+				fmt.Println(i)
+				for oID := i; oID < i+batchSize; oID++ {
+					olCnt := randInt(5, 15)
+					var carrierID interface{}
 					if oID < 2101 {
-						amount = 0
-						deliveryD = entryD
+						carrierID = strconv.Itoa(randInt(1, 10))
 					} else {
-						amount = float64(randInt(1, 999999)) / 100.0
-						deliveryD = sql.NullInt64{Int64: 0, Valid: false}
+						carrierID = "NULL"
+					}
+					if oID != i {
+						stmtStr += ","
+					}
+					stmtStr += fmt.Sprintf("(%d,%d,%d,%d,'%s',%s,%d,%d)",
+						oID, dID, wID, randomCIDs[oID-1], nowString, carrierID, olCnt, 1)
+
+					// The last 900 orders have entries in new orders.
+					if oID >= 2101 {
+						if haveNewOrders {
+							stmtNewOrderStr += ","
+						}
+						haveNewOrders = true
+						stmtNewOrderStr += fmt.Sprintf("(%d,%d,%d)", oID, dID, wID)
 					}
 
-					if _, err := stmtOrderLine.Exec(oID, dID, wID, olNumber,
-						randInt(1, 100000), // ol_i_id
-						wID,                // supply_w_id
-						deliveryD,
-						5, // quantity
-						amount,
-						randAString(24, 24)); err != nil {
+					// Random number between 5 and 15 of order lines per order.
+					orderLineStr := `INSERT INTO order_line (ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_delivery_d, ol_quantity, ol_amount, ol_dist_info) VALUES `
+					for olNumber := 1; olNumber <= olCnt; olNumber++ {
+						if olNumber != 1 {
+							orderLineStr += ","
+						}
+						var amount float64
+						var deliveryD interface{}
+						if oID < 2101 {
+							amount = 0
+							deliveryD = "'" + nowString + "'"
+						} else {
+							amount = float64(randInt(1, 999999)) / 100.0
+							deliveryD = "NULL"
+						}
+
+						orderLineStr += fmt.Sprintf("(%d,%d,%d,%d,%d,%d,%s,%d,%f,'%s')",
+							oID, dID, wID, olNumber,
+							randInt(1, 100000), // ol_i_id
+							wID,                // supply_w_id
+							deliveryD,
+							5, // quantity
+							amount,
+							randAString(24, 24))
+					}
+					if _, err := db.Exec(orderLineStr); err != nil {
 						panic(err)
 					}
 				}
-
-				// The last 900 orders have entries in new orders.
-				if oID >= 2101 {
-					if _, err := stmtNewOrder.Exec(oID, dID, wID); err != nil {
+				if _, err := db.Exec(stmtStr); err != nil {
+					panic(err)
+				}
+				if haveNewOrders {
+					if _, err := db.Exec(stmtNewOrderStr); err != nil {
 						panic(err)
 					}
 				}

--- a/tpcc/generate.go
+++ b/tpcc/generate.go
@@ -86,9 +86,10 @@ func parallelLoad(n int, batchSize int, entityName string, loader func(int, int)
 
 	i := 1
 	for range outCh {
-		fmt.Printf("Loaded %d/%d %ss\n", i*batchSize, n, entityName)
+		fmt.Printf("Loaded %d/%d %ss\r", i*batchSize, n, entityName)
 		i++
 	}
+	fmt.Printf("\n")
 	elapsed := time.Since(start)
 	fmt.Printf("%s\t%8d\t%12.1f ns/op\n",
 		"TPCCLoad"+strings.Title(entityName), n, float64(elapsed.Nanoseconds())/float64(n))
@@ -106,8 +107,6 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`)
 
 	// See section 1.3 for the general layout of the tables.
 	// See section 4.3 for the rules on how to populate the database.
-
-	fmt.Println("Loading items...")
 
 	// 100,000 items.
 	parallelLoad(nItems, 1000, "item", func(id int, batchSize int) {
@@ -129,10 +128,12 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`)
 		}
 	})
 
-	now := time.Now()
-	nowString := now.Format("2006-01-02 15:04:05")
 	for wID := 0; wID < *warehouses; wID++ {
-		fmt.Printf("Loading warehouse %d...\n", wID)
+		fmt.Printf("Loading warehouse %d/%d\n", wID+1, *warehouses)
+
+		warehouseStart := time.Now()
+		nowString := warehouseStart.Format("2006-01-02 15:04:05")
+
 		if _, err := stmtWarehouse.Exec(wID,
 			randInt(6, 10),  // name
 			randInt(10, 20), // street_1
@@ -182,7 +183,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`)
 
 		// 10 districts per warehouse
 		for dID := 1; dID <= 10; dID++ {
-			fmt.Printf("Loading warehouse %d district %d...\n", wID, dID)
+			fmt.Printf("Loading district %d/10...\n", dID)
 			if _, err := stmtDistrict.Exec(dID, wID,
 				randAString(6, 10),  // name
 				randAString(10, 20), // street 1
@@ -271,7 +272,6 @@ VALUES `
 				stmtStr := `INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES `
 				stmtNewOrderStr := `INSERT INTO new_order (no_o_id, no_d_id, no_w_id) VALUES `
 				haveNewOrders := false
-				fmt.Println(i)
 				for oID := i; oID < i+batchSize; oID++ {
 					olCnt := randInt(5, 15)
 					var carrierID interface{}
@@ -333,7 +333,7 @@ VALUES `
 					}
 				}
 			})
-			fmt.Printf("Loaded warehouse %d district %d\n", wID, dID)
 		}
+		fmt.Printf("Loaded warehouse in %0.1fs\n", time.Since(warehouseStart).Seconds())
 	}
 }

--- a/tpcc/main.go
+++ b/tpcc/main.go
@@ -122,9 +122,7 @@ func main() {
 	}
 
 	if *load || *loadIndexes {
-		fmt.Println("Loading indexes...")
 		loadSchema(db, *interleave, true)
-		fmt.Println("Done.")
 	}
 
 	initializeMix()

--- a/tpcc/main.go
+++ b/tpcc/main.go
@@ -38,6 +38,7 @@ var drop = flag.Bool("drop", false, "Drop the database and recreate")
 var duration = flag.Duration("duration", 0, "The duration to run. If 0, run forever.")
 var interleave = flag.Bool("interleave", false, "Use interleaved data")
 var load = flag.Bool("load", false, "Generate fresh TPCC data. Use with -drop")
+var loadIndexes = flag.Bool("load-indexes", false, "Load indexes. Implied by load. Don't need to use this normally.")
 var maxOps = flag.Uint64("max-ops", 0, "Maximum number of operations to run")
 var opsStats = flag.Bool("ops-stats", false, "Print stats for all operations, not just tpmC")
 var tolerateErrors = flag.Bool("tolerate-errors", false, "Keep running on error")
@@ -116,8 +117,14 @@ func main() {
 			fmt.Println("couldn't create database:", err)
 			os.Exit(1)
 		}
-		loadSchema(db, *interleave)
+		loadSchema(db, *interleave, false)
 		generateData(db)
+	}
+
+	if *load || *loadIndexes {
+		fmt.Println("Loading indexes...")
+		loadSchema(db, *interleave, true)
+		fmt.Println("Done.")
 	}
 
 	initializeMix()


### PR DESCRIPTION
- Load indexes and FKs at the end
- Batch inserts
- Improve shininess of loading process

Now it loads a warehouse in about 30 seconds, a big improvement from the several minutes it used to take. Loading isn't measured for the benchmark, but it's a nice productivity improvement when testing the benchmark.

The batch inserts part abandons the use of prepared statements because it's easier to just make a giant interpolated string. Maybe I'll get to fixing that later, but for now this is good enough.