### PR TITLE
ycsb: Use prepared statements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ check:
 	  grep -vE '^vet: cannot process directory .git'
 	@echo "vet --shadow"
 	@! go tool vet --shadow $(PKG) 2>&1 | \
-	  grep -vE '(declaration of err shadows|^vet: cannot process directory \.git)'
+	  grep -vE '(declaration of err shadows|declaration of "err" shadows|^vet: cannot process directory \.git)'
 	@echo "golint"
 	@! ./bin/golint $(PKG) | grep -vE '(\.pb\.go|_string)'
 	@echo "gofmt (simplify)"


### PR DESCRIPTION
This gives a 15% throughput improvement running on my macbook against
cockroach SHA 62b7495302a8e06b4be3780e349d10d31e378bd7.

before:
elapsed__ops/sec(total)__errors(total)
 302.9s        10623.1              0

after:
elapsed__ops/sec(total)__errors(total)
 323.9s        12110.6              0

We could also presumably get a free boost out of preparing the tpc-c statements, as well. I'll tack that on if we're generally in favor of using prepared statements in benchmarks.