### PR TITLE
ycsb: don't override cluster read consistency setting on reads

### DIFF
--- a/kv/main.go
+++ b/kv/main.go
@@ -520,7 +520,7 @@ func (c *cassandra) read(count int, g generator) error {
 	var v []byte
 	if err := c.session.Query(
 		`SELECT v FROM test.`+*tableName+` WHERE k = ? LIMIT 1`,
-		g.readKey()).Consistency(gocql.One).Scan(&v); err != nil {
+		g.readKey()).Scan(&v); err != nil {
 		if err == gocql.ErrNotFound {
 			return nil
 		}

--- a/ycsb/main.go
+++ b/ycsb/main.go
@@ -583,7 +583,7 @@ func (c *cassandra) readRow(key uint64) (bool, error) {
 	var fields [10]string
 	if err := c.session.Query(
 		`SELECT * FROM ycsb.usertable WHERE ycsb_key = ? LIMIT 1`,
-		key).Consistency(gocql.One).Scan(&k, &fields[0], &fields[1], &fields[2], &fields[3],
+		key).Scan(&k, &fields[0], &fields[1], &fields[2], &fields[3],
 		&fields[4], &fields[5], &fields[6], &fields[7], &fields[8], &fields[9]); err != nil {
 		if err == gocql.ErrNotFound {
 			return true, nil


### PR DESCRIPTION
We were overriding the cluster read consistency setting for reads and
always using a read consistency of ONE. Doing so was making the
--cassandra-consistency flag a lie.