### PR TITLE
tpcc: make pg compatible

### DIFF
--- a/tpcc/delivery.go
+++ b/tpcc/delivery.go
@@ -51,7 +51,7 @@ func (del delivery) run(db *sql.DB, wID int) (interface{}, error) {
 	if err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&sql.TxOptions{Isolation: sql.LevelSerializable},
+		txOpts,
 		func(tx *sql.Tx) error {
 			getNewOrder, err := tx.Prepare(`
 			SELECT no_o_id

--- a/tpcc/new_order.go
+++ b/tpcc/new_order.go
@@ -121,7 +121,7 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 	err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&sql.TxOptions{Isolation: sql.LevelSerializable},
+		txOpts,
 		func(tx *sql.Tx) error {
 			// Select the warehouse tax rate.
 			if err := tx.QueryRow(

--- a/tpcc/stock_level.go
+++ b/tpcc/stock_level.go
@@ -60,7 +60,7 @@ func (s stockLevel) run(db *sql.DB, wID int) (interface{}, error) {
 	if err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&sql.TxOptions{Isolation: sql.LevelSerializable},
+		txOpts,
 		func(tx *sql.Tx) error {
 			var dNextOID int
 			if err := tx.QueryRow(`


### PR DESCRIPTION
If tpcc is run against a Postgres server (inferred by whether the
database port is 5432), it uses Postgres-compatible schema and set of
queries.

A few things had to change:

1. Postgres doesn't permit descending columns in primary indexes, so we
   got rid of those. I'm not sure if that's to spec.
2. Dropping the database has to be done by dropping the schema instead
   of the database, since you can't drop databases as easily in
   Postgres.
3. Postgres' default transaction isolation is read committed, so a new
   option -serializable was introduced to force serializable mode if
   desired.