### PR TITLE
tpcc: batch all writes in newOrder txn

### DIFF
--- a/tpcc/new_order.go
+++ b/tpcc/new_order.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math/rand"
+	"sort"
 	"strings"
 	"time"
 
@@ -42,6 +43,7 @@ import (
 type orderItem struct {
 	olSupplyWID  int    // supplying warehouse id
 	olIID        int    // item id
+	olNumber     int    // item number in order
 	iName        string // item name
 	olQuantity   int    // order quantity
 	sQuantity    int    // stock quantity
@@ -86,6 +88,11 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 	}
 	d.items = make([]orderItem, d.oOlCnt)
 
+	// itemIDs tracks the item ids in the order so that we can prevent adding
+	// multiple items with the same ID. This would not make sense because each
+	// orderItem already tracks a quantity that can be larger than 1.
+	itemIDs := make(map[int]struct{})
+
 	// 2.4.1.4: A fixed 1% of the New-Order transactions are chosen at random to
 	// simulate user data entry errors and exercise the performance of rolling
 	// back update transactions.
@@ -95,6 +102,7 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 	allLocal := 1
 	for i := 0; i < d.oOlCnt; i++ {
 		item := orderItem{
+			olNumber: i + 1,
 			// 2.4.1.5.3: order has a quantity [1..10]
 			olQuantity: rand.Intn(10) + 1,
 		}
@@ -103,7 +111,14 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 		if rollback && i == d.oOlCnt-1 {
 			item.olIID = -1
 		} else {
-			item.olIID = randItemID()
+			// Loop until we find a unique item ID.
+			for {
+				item.olIID = randItemID()
+				if _, ok := itemIDs[item.olIID]; !ok {
+					itemIDs[item.olIID] = struct{}{}
+					break
+				}
+			}
 		}
 		// 2.4.1.5.2: 1% of the time, an item is supplied from a remote warehouse.
 		item.remoteWarehouse = rand.Intn(100) == 0
@@ -116,6 +131,11 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 		d.items[i] = item
 	}
 
+	// Sort the items in the same order that we will require from batch select queries.
+	sort.Slice(d.items, func(i, j int) bool {
+		return d.items[i].olIID < d.items[j].olIID
+	})
+
 	d.oEntryD = time.Now()
 
 	err := crdb.ExecuteTx(
@@ -123,14 +143,6 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 		db,
 		txOpts,
 		func(tx *sql.Tx) error {
-			// Select the warehouse tax rate.
-			if err := tx.QueryRow(
-				`SELECT w_tax FROM warehouse WHERE w_id = $1`,
-				wID,
-			).Scan(&d.wTax); err != nil {
-				return err
-			}
-
 			// Select the district tax rate and next available order number, bumping it.
 			var dNextOID int
 			if err := tx.QueryRow(`
@@ -142,8 +154,15 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 			).Scan(&d.dTax, &dNextOID); err != nil {
 				return err
 			}
-
 			d.oID = dNextOID - 1
+
+			// Select the warehouse tax rate.
+			if err := tx.QueryRow(
+				`SELECT w_tax FROM warehouse WHERE w_id = $1`,
+				wID,
+			).Scan(&d.wTax); err != nil {
+				return err
+			}
 
 			// Select the customer's discount, last name and credit.
 			if err := tx.QueryRow(`
@@ -154,6 +173,124 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 			).Scan(&d.cDiscount, &d.cLast, &d.cCredit); err != nil {
 				return err
 			}
+
+			// 2.4.2.2: For each o_ol_cnt item in the order, query the relevant item
+			// row, update the stock row to account for the order, and insert a new
+			// line into the order_line table to reflect the item on the order.
+			itemIDs := make([]interface{}, d.oOlCnt)
+			itemIDPls := make([]string, d.oOlCnt)
+			for i, item := range d.items {
+				itemIDs[i] = item.olIID
+				itemIDPls[i] = fmt.Sprintf("$%d", i+1)
+			}
+			rows, err := tx.Query(fmt.Sprintf(`
+				SELECT i_price, i_name, i_data
+				FROM item
+				WHERE i_id IN (%s)
+				ORDER BY i_id`,
+				strings.Join(itemIDPls, ", ")),
+				itemIDs...,
+			)
+			if err != nil {
+				return err
+			}
+			iDatas := make([]string, d.oOlCnt)
+			for i := range d.items {
+				item := &d.items[i]
+				iData := &iDatas[i]
+
+				if !rows.Next() {
+					if rollback {
+						// 2.4.2.3: roll back when we're expecting a rollback due to
+						// simulated user error (invalid item id) and we actually
+						// can't find the item. The spec requires us to actually go
+						// to the database for this, even though we know earlier
+						// that the item has an invalid number.
+						return errSimulated
+					}
+					return errors.New("missing item row")
+				}
+
+				err = rows.Scan(&item.iPrice, &item.iName, iData)
+				if err != nil {
+					rows.Close()
+					return err
+				}
+			}
+			if rows.Next() {
+				return errors.New("extra item row")
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			rows.Close()
+
+			stockIDs := make([]interface{}, 2*d.oOlCnt)
+			stockIDPls := make([]string, d.oOlCnt)
+			for i, item := range d.items {
+				stockIDs[2*i] = item.olIID
+				stockIDs[2*i+1] = item.olSupplyWID
+				stockIDPls[i] = fmt.Sprintf("($%d, $%d)", 2*i+1, 2*i+2)
+			}
+			rows, err = tx.Query(fmt.Sprintf(`
+				SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_%02d
+				FROM stock
+				WHERE (s_i_id, s_w_id) IN (%s)
+				ORDER BY s_i_id`,
+				d.dID, strings.Join(stockIDPls, ", ")),
+				stockIDs...,
+			)
+			if err != nil {
+				return err
+			}
+			distInfos := make([]string, d.oOlCnt)
+			sQuantityUpdateCases := make([]string, d.oOlCnt)
+			sYtdUpdateCases := make([]string, d.oOlCnt)
+			sOrderCntUpdateCases := make([]string, d.oOlCnt)
+			sRemoteCntUpdateCases := make([]string, d.oOlCnt)
+			for i := range d.items {
+				item := &d.items[i]
+
+				if !rows.Next() {
+					return errors.New("missing stock row")
+				}
+
+				var sQuantity, sYtd, sOrderCnt, sRemoteCnt int
+				var sData string
+				err = rows.Scan(&sQuantity, &sYtd, &sOrderCnt, &sRemoteCnt, &sData, &distInfos[i])
+				if err != nil {
+					rows.Close()
+					return err
+				}
+
+				if strings.Contains(sData, originalString) && strings.Contains(iDatas[i], originalString) {
+					item.brandGeneric = "B"
+				} else {
+					item.brandGeneric = "G"
+				}
+
+				newSQuantity := sQuantity - item.olQuantity
+				if sQuantity < item.olQuantity+10 {
+					newSQuantity += 91
+				}
+
+				newSRemoteCnt := sRemoteCnt
+				if item.remoteWarehouse {
+					newSRemoteCnt++
+				}
+
+				sQuantityUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDPls[i], newSQuantity)
+				sYtdUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDPls[i], sYtd+item.olQuantity)
+				sOrderCntUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDPls[i], sOrderCnt+1)
+				sRemoteCntUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDPls[i], newSRemoteCnt)
+			}
+			if rows.Next() {
+				return errors.New("extra stock row")
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			rows.Close()
 
 			// Insert row into the orders and new orders table.
 			if _, err := tx.Exec(`
@@ -169,74 +306,52 @@ func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
 				return err
 			}
 
-			selectItem, err := tx.Prepare(`SELECT i_price, i_name, i_data FROM item WHERE i_id=$1`)
-			if err != nil {
-				return err
-			}
-			updateStock, err := tx.Prepare(fmt.Sprintf(`
-			UPDATE stock
-			SET (s_quantity, s_ytd, s_order_cnt, s_remote_cnt) =
-				(CASE s_quantity >= $1 + 10 WHEN true THEN s_quantity-$1 ELSE (s_quantity-$1)+91 END,
-				 s_ytd + $1,
-				 s_order_cnt + 1,
-				 s_remote_cnt + (CASE $2::bool WHEN true THEN 1 ELSE 0 END))
-			WHERE s_i_id=$3 AND s_w_id=$4
-			RETURNING s_dist_%02d, s_data`, d.dID))
-			if err != nil {
-				return err
-			}
-			insertOrderLine, err := tx.Prepare(`
-			INSERT INTO order_line(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`)
-			if err != nil {
+			// Update the stock table for each item.
+			if _, err := tx.Exec(fmt.Sprintf(`
+				UPDATE stock
+				SET
+					s_quantity = CASE (s_i_id, s_w_id) %s ELSE crdb_internal.force_error('', 'unknown case') END,
+					s_ytd = CASE (s_i_id, s_w_id) %s END,
+					s_order_cnt = CASE (s_i_id, s_w_id) %s END,
+					s_remote_cnt = CASE (s_i_id, s_w_id) %s END
+				WHERE (s_i_id, s_w_id) IN (%s)`,
+				strings.Join(sQuantityUpdateCases, " "),
+				strings.Join(sYtdUpdateCases, " "),
+				strings.Join(sOrderCntUpdateCases, " "),
+				strings.Join(sRemoteCntUpdateCases, " "),
+				strings.Join(stockIDPls, ", ")),
+				stockIDs...,
+			); err != nil {
 				return err
 			}
 
-			var iData string
-			// 2.4.2.2: For each o_ol_cnt item in the order, query the relevant item
-			// row, update the stock row to account for the order, and insert a new
-			// line into the order_line table to reflect the item on the order.
-			for i, item := range d.items {
-				if err := selectItem.QueryRow(item.olIID).Scan(&item.iPrice, &item.iName, &iData); err != nil {
-					if rollback && item.olIID < 0 {
-						// 2.4.2.3: roll back when we're expecting a rollback due to
-						// simulated user error (invalid item id) and we actually
-						// can't find the item. The spec requires us to actually go
-						// to the database for this, even though we know earlier
-						// that the item has an invalid number.
-						return errSimulated
-					}
-					return err
-				}
-
-				var distInfo, sData string
-				if err := updateStock.QueryRow(
-					item.olQuantity, item.remoteWarehouse, item.olIID, item.olSupplyWID,
-				).Scan(&distInfo, &sData); err != nil {
-					return err
-				}
-				if strings.Contains(sData, originalString) && strings.Contains(iData, originalString) {
-					item.brandGeneric = "B"
-				} else {
-					item.brandGeneric = "G"
-				}
-
+			// Insert a new order line for each item in the order.
+			olValsStrings := make([]string, d.oOlCnt)
+			for i := range d.items {
+				item := &d.items[i]
 				item.olAmount = float64(item.olQuantity) * item.iPrice
 				d.totalAmount += item.olAmount
-				if _, err := insertOrderLine.Exec(
-					d.oID, // ol_o_id
-					d.dID,
-					d.wID,
-					i+1, // ol_number is a counter over the items in the order.
-					item.olIID,
-					item.olSupplyWID,
-					item.olQuantity,
-					item.olAmount,
-					distInfo, // ol_dist_info is set to the contents of s_dist_xx
-				); err != nil {
-					return err
-				}
+
+				olValsStrings[i] = fmt.Sprintf("(%d,%d,%d,%d,%d,%d,%d,%f,'%s')",
+					d.oID,            // ol_o_id
+					d.dID,            // ol_d_id
+					d.wID,            // ol_w_id
+					item.olNumber,    // ol_number
+					item.olIID,       // ol_i_id
+					item.olSupplyWID, // ol_supply_w_id
+					item.olQuantity,  // ol_quantity
+					item.olAmount,    // ol_amount
+					distInfos[i],     // ol_dist_info
+				)
 			}
+			if _, err := tx.Exec(fmt.Sprintf(`
+				INSERT INTO order_line(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
+				VALUES %s`,
+				strings.Join(olValsStrings, ", ")),
+			); err != nil {
+				return err
+			}
+
 			// 2.4.2.2: total_amount = sum(OL_AMOUNT) * (1 - C_DISCOUNT) * (1 + W_TAX + D_TAX)
 			d.totalAmount *= (1 - d.cDiscount) * (1 + d.wTax + d.dTax)
 

--- a/tpcc/order_status.go
+++ b/tpcc/order_status.go
@@ -118,6 +118,9 @@ func (o orderStatus) run(db *sql.DB, wID int) (interface{}, error) {
 					}
 					customers = append(customers, c)
 				}
+				if err := rows.Err(); err != nil {
+					return err
+				}
 				rows.Close()
 				cIdx := len(customers) / 2
 				if len(customers)%2 == 0 {
@@ -163,7 +166,7 @@ func (o orderStatus) run(db *sql.DB, wID int) (interface{}, error) {
 				}
 				d.items = append(d.items, item)
 			}
-			return nil
+			return rows.Err()
 		}); err != nil {
 		return nil, err
 	}

--- a/tpcc/payment.go
+++ b/tpcc/payment.go
@@ -162,6 +162,9 @@ func (p payment) run(db *sql.DB, wID int) (interface{}, error) {
 					}
 					customers = append(customers, cID)
 				}
+				if err := rows.Err(); err != nil {
+					return err
+				}
 				rows.Close()
 				cIdx := len(customers) / 2
 				if len(customers)%2 == 0 {


### PR DESCRIPTION
This change removes the iteration over each item an order in the `newOrder` transaction. It replaces
this iteration with batched operations that each work over all items in the order. This drastically reduces the number of statements that are run in the transaction and avoids O(item_count) round trips.