### PR TITLE
Always bind workers to warehouses

### DIFF
--- a/tpcc/stock_level.go
+++ b/tpcc/stock_level.go
@@ -57,17 +57,17 @@ func (s stockLevel) run(db *sql.DB, wID int) (interface{}, error) {
 		dID:       rand.Intn(9) + 1,
 	}
 
-	// This is the only join in the application, so we don't need to worry about
-	// this setting persisting incorrectly across queries.
-	if _, err := db.Exec(`set experimental_force_lookup_join=true`); err != nil {
-		return nil, err
-	}
-
 	if err := crdb.ExecuteTx(
 		context.Background(),
 		db,
 		txOpts,
 		func(tx *sql.Tx) error {
+			// This is the only join in the application, so we don't need to worry about
+			// this setting persisting incorrectly across queries.
+			if _, err := tx.Exec(`set experimental_force_lookup_join=true`); err != nil {
+				return err
+			}
+
 			var dNextOID int
 			if err := tx.QueryRow(`
 				SELECT d_next_o_id


### PR DESCRIPTION
Change the behavior when `-no-wait` is specified to assign each worker
to a warehouse. Previously each worker was selecting a random warehouse
to operate on. This allows experimentation with contention. For example,
`-warehouses=1 -concurrency=1 -no-wait` shows the throughput of a single
worker without contention. Specify higher values of concurrency to see
more contention. And we can also specify `-warehouses=10
-concurrency=10` to see scalability in the absence of contention.

Change the ramp-up behavior to factor in the think time as well. This is
an attempt to reduce the thundering herd effect we're seeing when the
load generator starts.