### PR TITLE
tpcc: use deck method of regulating txn mix

### DIFF
--- a/teamcity-push.sh
+++ b/teamcity-push.sh
@@ -48,7 +48,7 @@ for proj in kv ycsb tpch tpcc ; do
         --workdir=/go/src/github.com/cockroachdb/loadgen \
         --volume="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)":/go/src/github.com/cockroachdb/loadgen \
         --rm \
-        cockroachdb/builder:20170422-212842 make ${proj} STATIC=1
+        cockroachdb/builder:20180220-200046 make ${proj} STATIC=1
     strip -S ${proj}/${proj}
     push_one_binary ${proj}/${proj}
 done

--- a/teamcity-test.sh
+++ b/teamcity-test.sh
@@ -8,4 +8,4 @@ docker run \
     --volume="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)":/go/src/github.com/cockroachdb/loadgen \
     --volume="/tmp/loadgenbin":/go/src/github.com/cockroachdb/loadgen/bin \
     --rm \
-    cockroachdb/builder:20170422-212842 make all | go-test-teamcity
+    cockroachdb/builder:20180220-200046 make all | go-test-teamcity

--- a/tpcc/main.go
+++ b/tpcc/main.go
@@ -55,7 +55,7 @@ var warehouses = flag.Int("warehouses", 1, "number of warehouses for loading")
 var usePostgres bool
 var txOpts *sql.TxOptions
 
-var mix = flag.String("mix", "newOrder=45,payment=43,orderStatus=4,delivery=4,stockLevel=4", "Weights for the transaction mix. The default matches the TPCC spec.")
+var mix = flag.String("mix", "newOrder=10,payment=10,orderStatus=1,delivery=1,stockLevel=1", "Weights for the transaction mix. The default matches the TPCC spec.")
 
 const (
 	minLatency = 100 * time.Microsecond


### PR DESCRIPTION
The naive randomness used originally (picking randomly from the
transaction mix distribution without hysteris) leads to a potentially
invalid transaction mix.

The spec suggests using a deck of transactions to regulate the mix,
where the deck is iterated through in random order and shuffled when
exhausted. Now, we use that method.

Note that the default transaction mix changed slightly. The spec isn't
precise on what the transaction mix is, but it clearly says that the
deck method can be implemented with 10 cards for each of payment and new
order, and 1 each of the rest, so that's what the mix is now.