### PR TITLE
tpcc: permit loading a warehouse subset

### DIFF
--- a/tpcc/ddls.go
+++ b/tpcc/ddls.go
@@ -234,8 +234,8 @@ create table order_line (
 	},
 }
 
-// loadSchema loads the entire TPCC schema into the database.
-func loadSchema(db *sql.DB, interleave bool, index bool, usePostgres bool) {
+// doLoadSchema loads the entire TPCC schema into the database.
+func doLoadSchema(db *sql.DB, interleave bool, index bool, usePostgres bool) {
 	schemaType := "tables"
 	if index {
 		schemaType = "indexes"


### PR DESCRIPTION
Introduce new flags and functionality for improved parallel loading.

  -load-offset starts loading warehouses at a specified offset
  -load-indexes controls whether indexes will be built
  -load-schema controls whether schema will be built
  -conns-per-url controls the number of connections per url. if
    unspecified, the previous default of nWarehouses is kept.

Also improves the appearance of the loading process to make it more
clear what the current phase is.