### PR TITLE
tpcc: refactor checks 1 through 5

### DIFF
--- a/tpcc/check.go
+++ b/tpcc/check.go
@@ -3,129 +3,274 @@ package main
 import (
 	"database/sql"
 	"fmt"
+
+	"time"
+
+	"github.com/pkg/errors"
 )
 
-func forEachWarehouseAndDistrict(fn func(wID, dID int) error) error {
-	for wID := 0; wID < *warehouses; wID++ {
-		for dID := 1; dID < 10; dID++ {
-			if err := fn(wID, dID); err != nil {
-				return err
-			}
-		}
+func check3321(db *sql.DB) error {
+	// 3.3.2.1 Entries in the WAREHOUSE and DISTRICT tables must satisfy the relationship:
+	// W_YTD = sum (D_YTD)
+
+	row := db.QueryRow(`
+SELECT COUNT(*) 
+FROM warehouse 
+FULL OUTER JOIN 
+(SELECT d_w_id, SUM(d_ytd) as sum_d_ytd FROM district GROUP BY d_w_id) 
+ON (w_id = d_w_id)
+WHERE w_ytd != sum_d_ytd
+`)
+
+	var i int
+	if err := row.Scan(&i); err != nil {
+		return err
 	}
+
+	if i != 0 {
+		return errors.Errorf("%d rows returned, expected zero", i)
+	}
+
 	return nil
 }
 
-func checkConsistency(db *sql.DB) error {
-	// Reused checks
+func check3322(db *sql.DB) error {
+	// Entries in the DISTRICT, ORDER, and NEW-ORDER tables must satisfy the relationship:
+	// D_NEXT_O_ID - 1 = max(O_ID) = max(NO_O_ID)
 
-	maxNewOIDs := make([]int, *warehouses*10)
-
-	sliceIdx := func(wID, dID int) int {
-		return wID*10 + dID - 1
+	districtRows, err := db.Query("SELECT d_next_o_id FROM district ORDER BY d_w_id, d_id")
+	if err != nil {
+		return err
 	}
-
-	// 3.3.2.1
-	// W_YTD = sum(D_YTD) for all warehouses and districts
-	var wYTD, sumDYTD float64
-	for i := 0; i < *warehouses; i++ {
-		if err := db.QueryRow("SELECT w_ytd FROM warehouse WHERE w_id=$1", i).Scan(&wYTD); err != nil {
-			return err
-		}
-		if err := db.QueryRow("SELECT SUM(d_ytd) FROM district WHERE d_w_id=$1", i).Scan(&sumDYTD); err != nil {
-			return err
-		}
-		if wYTD != sumDYTD {
-			fmt.Printf("check failed: w_ytd=%f != sum(d_ytd)=%f for warehouse %d\n", wYTD, sumDYTD, i)
-		}
+	newOrderRows, err := db.Query(`
+SELECT MAX(no_o_id) FROM tpcc.new_order GROUP BY no_d_id, no_w_id ORDER BY no_w_id, no_d_id
+`)
+	if err != nil {
+		return err
 	}
-
-	// 3.3.2.2
-	// D_NEXT_O_ID - 1 = max(O_ID) = max(NO_O_ID) for all districts
-	var dNextOID, maxOID, maxNewOID int
-	if err := forEachWarehouseAndDistrict(func(wID, dID int) error {
-		if err := db.QueryRow(`SELECT d_next_o_id FROM district WHERE d_w_id=$1 AND d_id=$2`,
-			wID, dID,
-		).Scan(&dNextOID); err != nil {
-			return err
-		}
-		if err := db.QueryRow(`SELECT max(o_id) FROM "order" WHERE o_w_id=$1 AND o_d_id=$2`,
-			wID, dID,
-		).Scan(&maxOID); err != nil {
-			return err
-		}
-		if err := db.QueryRow(`SELECT max(no_o_id) FROM new_order WHERE no_w_id=$1 AND no_d_id=$2`,
-			wID, dID,
-		).Scan(&maxNewOID); err != nil {
-			return err
-		}
-		maxNewOIDs[sliceIdx(wID, dID)] = maxNewOID
-
-		if dNextOID != maxOID+1 || dNextOID != maxNewOID+1 {
-			fmt.Printf("check failed: d_next_o_id=%d != max(o_id)+1=%d != max(no_o_id)+1=%d for warehouse %d district %d\n",
-				dNextOID, maxOID, maxNewOID, wID, dID)
-		}
-		return nil
-	}); err != nil {
+	orderRows, err := db.Query(`
+SELECT MAX(o_id) FROM tpcc.order GROUP BY o_d_id, o_w_id ORDER BY o_w_id, o_d_id
+`)
+	if err != nil {
 		return err
 	}
 
-	// 3.3.2.3
-	// max(NO_O_ID) - min(NO_O_ID) + 1 = # of rows in new_order for each warehouse/district
-	var minNewOID, countNewOrder int
-	if err := forEachWarehouseAndDistrict(func(wID, dID int) error {
-		if err := db.QueryRow(`SELECT min(no_o_id), count(*) FROM new_order WHERE no_w_id=$1 AND no_d_id=$2`,
-			wID, dID,
-		).Scan(&minNewOID, &countNewOrder); err != nil {
+	var district, newOrder, order float64
+	var i int
+	for ; districtRows.Next() && newOrderRows.Next() && orderRows.Next(); i++ {
+		if err := districtRows.Scan(&district); err != nil {
 			return err
 		}
-		maxNewOID := maxNewOIDs[sliceIdx(wID, dID)]
-		if maxNewOID-minNewOID+1 != countNewOrder {
-			fmt.Printf("check failed: max(no_o_id)=%d + min(no_o_id)=%d + 1 != count(*)=%d for w_id=%d d_id=%d\n",
-				maxNewOID, minNewOID, countNewOrder, wID, dID)
+		if err := newOrderRows.Scan(&newOrder); err != nil {
+			return err
 		}
-		return nil
-	}); err != nil {
+		if err := orderRows.Scan(&order); err != nil {
+			return err
+		}
+
+		if (order != newOrder) || (order != (district - 1)) {
+			return errors.Errorf("inequality at idx %d: order: %d, newOrder: %d, district-1: %d",
+				i, order, newOrder, district-1)
+		}
+	}
+	if districtRows.Next() || newOrderRows.Next() || orderRows.Next() {
+		return errors.New("length mismatch between rows")
+	}
+	if err := districtRows.Close(); err != nil {
+		return err
+	}
+	if err := newOrderRows.Close(); err != nil {
+		return err
+	}
+	if err := orderRows.Close(); err != nil {
 		return err
 	}
 
-	// 3.3.2.4
-	// sum(O_OL_CNT) = # of rows in the ORDER-LINE table for each warehouse/district
-	var sumOOLCnt, countNewOrderLine int
-	if err := forEachWarehouseAndDistrict(func(wID, dID int) error {
-		if err := db.QueryRow(`SELECT sum(o_ol_cnt) FROM "order" WHERE o_w_id=$1 AND o_d_id=$2`,
-			wID, dID,
-		).Scan(&sumOOLCnt); err != nil {
-			return err
-		}
-		if err := db.QueryRow(`SELECT count(*) FROM order_line WHERE ol_w_id=$1 AND ol_d_id=$2`,
-			wID, dID,
-		).Scan(&countNewOrderLine); err != nil {
-			return err
-		}
-		if countNewOrderLine != sumOOLCnt {
-			fmt.Printf("check failed: count(order_line)=%d != sum(o_ol_cnt)=%d for w_id=%d d_id=%d\n",
-				countNewOrderLine, sumOOLCnt, wID, dID)
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	// 3.3.2.8
-	// W_YTD = sum(H_AMOUNT) for each warehouse
-	var sumHAmount float64
-	for i := 0; i < *warehouses; i++ {
-		if err := db.QueryRow("SELECT w_ytd FROM warehouse WHERE w_id=$1", i).Scan(&wYTD); err != nil {
-			return err
-		}
-		if err := db.QueryRow("SELECT SUM(h_amount) FROM history WHERE h_w_id=$1", i).Scan(&sumHAmount); err != nil {
-			return err
-		}
-		if wYTD != sumHAmount {
-			fmt.Printf("check failed: w_ytd=%f != sum(h_amount)=%f for warehouse %d\n", wYTD, sumHAmount, i)
-		}
+	if i == 0 {
+		return errors.Errorf("zero rows")
 	}
 
 	return nil
+}
+
+func check3323(db *sql.DB) error {
+	// max(NO_O_ID) - min(NO_O_ID) + 1 = # of rows in new_order for each warehouse/district
+	rows, err := db.Query(`
+SELECT (VALUES (1)) FULL OUTER JOIN
+(SELECT MAX(no_o_id) - MIN(no_o_id) - COUNT(*) AS nod FROM new_order GROUP BY no_w_id, no_d_id)
+ WHERE nod != one
+`)
+	if err != nil {
+		return err
+	}
+
+	var i int
+	var val int
+	for ; rows.Next(); i++ {
+		if err := rows.Scan(&val); err != nil {
+			return err
+		}
+		if val != -1 {
+			return errors.Errorf("MAX(no_o_id) - MIN(no_o_id) - COUNT(rows) must be -1, got %d", val)
+		}
+	}
+
+	if err := rows.Close(); err != nil {
+		return err
+	}
+
+	if i == 0 {
+		return errors.Errorf("zero rows")
+	}
+
+	return nil
+}
+
+func check3324(db *sql.DB) error {
+	// SUM(O_OL_CNT) = [number of rows in the ORDER-LINE table for this district]
+
+	leftRows, err := db.Query(`
+SELECT SUM(o_ol_cnt) FROM tpcc.order GROUP BY o_w_id, o_d_id ORDER BY o_w_id, o_d_id
+`)
+	if err != nil {
+		return err
+	}
+	rightRows, err := db.Query(`
+SELECT COUNT(*) FROM tpcc.order_line GROUP BY ol_w_id, ol_d_id ORDER BY ol_w_id, ol_d_id
+`)
+	if err != nil {
+		return err
+	}
+	var i int
+	var left, right int64
+	for ; leftRows.Next() && rightRows.Next(); i++ {
+		if err := leftRows.Scan(&left); err != nil {
+			return err
+		}
+		if err := rightRows.Scan(&right); err != nil {
+			return err
+		}
+		if left != right {
+			return errors.Errorf("order.SUM(o_ol_cnt): %d != order_line.count(*): %d", left, right)
+		}
+	}
+	if i == 0 {
+		return errors.Errorf("0 rows returned")
+	}
+	if leftRows.Next() || rightRows.Next() {
+		return errors.Errorf("length of order.SUM(o_ol_cnt) != order_line.count(*)")
+	}
+
+	if err := leftRows.Close(); err != nil {
+		return err
+	}
+	return rightRows.Close()
+}
+
+func check3325(db *sql.DB) error {
+	// We want the symmetric difference between the sets:
+	// (SELECT no_w_id, no_d_id, no_o_id FROM tpcc.new_order)
+	// (SELECT o_w_id, o_d_id, o_id FROM tpcc.order@primary WHERE o_carrier_id IS NULL)
+	// We achieve this by two EXCEPT ALL queries.
+
+	firstQuery, err := db.Query(`
+(SELECT no_w_id, no_d_id, no_o_id FROM tpcc.new_order) 
+EXCEPT ALL 
+(SELECT o_w_id, o_d_id, o_id FROM tpcc.order@primary WHERE o_carrier_id IS NULL)`)
+	if err != nil {
+		return err
+	}
+	secondQuery, err := db.Query(`
+(SELECT o_w_id, o_d_id, o_id FROM tpcc.order@primary WHERE o_carrier_id IS NULL) 
+EXCEPT ALL 
+(SELECT no_w_id, no_d_id, no_o_id FROM tpcc.new_order)`)
+	if err != nil {
+		return err
+	}
+
+	if firstQuery.Next() {
+		return errors.Errorf("left EXCEPT right returned nonzero results.")
+	}
+
+	if secondQuery.Next() {
+		return errors.Errorf("right EXCEPT left returned nonzero results.")
+	}
+
+	if err := firstQuery.Close(); err != nil {
+		return err
+	}
+	return secondQuery.Close()
+}
+
+func check3326(db *sql.DB) error {
+	firstQuery, err := db.Query(`
+(SELECT o_w_id, o_d_id, o_id, o_ol_cnt FROM tpcc.order 
+  ORDER BY o_w_id, o_d_id, o_id DESC) 
+EXCEPT ALL 
+(SELECT ol_w_id, ol_d_id, ol_o_id, COUNT(*) FROM tpcc.order_line 
+  GROUP BY (ol_w_id, ol_d_id, ol_o_id) 
+  ORDER BY ol_w_id, ol_d_id, ol_o_id DESC)`)
+	if err != nil {
+		return err
+	}
+	secondQuery, err := db.Query(`
+(SELECT ol_w_id, ol_d_id, ol_o_id, COUNT(*) FROM tpcc.order_line 
+  GROUP BY (ol_w_id, ol_d_id, ol_o_id) ORDER BY ol_w_id, ol_d_id, ol_o_id DESC) 
+EXCEPT ALL 
+(SELECT o_w_id, o_d_id, o_id, o_ol_cnt FROM tpcc.order 
+  ORDER BY o_w_id, o_d_id, o_id DESC)`)
+	if err != nil {
+		return err
+	}
+
+	if firstQuery.Next() {
+		return errors.Errorf("left EXCEPT right returned nonzero results")
+	}
+
+	if secondQuery.Next() {
+		return errors.Errorf("right EXCEPT left returned nonzero results")
+	}
+
+	if err := firstQuery.Close(); err != nil {
+		return err
+	}
+	return secondQuery.Close()
+}
+
+func checkConsistency(db *sql.DB) bool {
+	type check struct {
+		name      string
+		f         func(db *sql.DB) error
+		expensive bool
+	}
+
+	checks := []check{
+		{"3.3.2.1", check3321, false},
+		{"3.3.2.2", check3322, false},
+		{"3.3.2.3", check3323, false},
+		{"3.3.2.4", check3324, false},
+		{"3.3.2.5", check3325, false},
+		{"3.3.2.6", check3326, true},
+	}
+	var errorEncountered bool
+
+	// TODO(arjun): We should run each test in a single transaction as currently
+	// we have to shut down load before running the checks.
+
+	for _, check := range checks {
+		if check.expensive && !*expensive {
+			continue
+		}
+		start := time.Now()
+		fmt.Printf(check.name)
+		if err := check.f(db); err != nil {
+			fmt.Printf(": error encountered: '%+v'", err)
+			errorEncountered = true
+		} else {
+			fmt.Printf(" passed")
+		}
+
+		fmt.Printf(" after %f seconds.\n", time.Since(start).Seconds())
+	}
+	return errorEncountered
 }

--- a/tpcc/main.go
+++ b/tpcc/main.go
@@ -37,6 +37,7 @@ var check = flag.Bool("check", false, "Run consistency checks.")
 var concurrency = flag.Int("concurrency", 2*runtime.NumCPU(), "Number of terminals (ignored unless -no-wait is specified)")
 var drop = flag.Bool("drop", false, "Drop the database and recreate")
 var duration = flag.Duration("duration", 0, "The duration to run. If 0, run forever.")
+var expensive = flag.Bool("expensive", false, "Run expensive checks. (ignored unless -check is specified)")
 var interleave = flag.Bool("interleave", false, "Use interleaved data")
 var load = flag.Bool("load", false, "Generate fresh TPCC data. Use with -drop")
 var loadIndexes = flag.Bool("load-indexes", false, "Load indexes. Implied by load. Don't need to use this normally.")
@@ -85,8 +86,10 @@ func setupDatabase(parsedURL *url.URL, dbName string, nConns int) (*sql.DB, erro
 		return nil, err
 	}
 
-	db.SetMaxOpenConns(nConns)
-	db.SetMaxIdleConns(nConns)
+	if !*check {
+		db.SetMaxOpenConns(nConns)
+		db.SetMaxIdleConns(nConns)
+	}
 
 	return db, nil
 }
@@ -193,8 +196,8 @@ func main() {
 	}
 
 	if *check {
-		if err := checkConsistency(db); err != nil {
-			fmt.Printf("check consistency failed: %v\n", err)
+		if err := checkConsistency(db); err != false {
+			fmt.Printf("check consistency failed\n")
 			os.Exit(1)
 		}
 		os.Exit(0)


### PR DESCRIPTION
On 100 warehouses, the checks now take:

3.3.2.1: 100 rows, passed in 0.061173 seconds.
3.3.2.2: 1000 rows, passed in 4.662491 seconds.
3.3.2.3: 1000 rows, passed in 1.034691 seconds.
3.3.2.4: 1000 rows, passed in 30.794494 seconds.
3.3.2.5: passed in 21.333984 seconds.