### PR TITLE
tpcc: add auditor and initial check

### DIFF
--- a/tpcc/audit.go
+++ b/tpcc/audit.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/pkg/errors"
+)
+
+// auditor maintains statistics about TPC-C input data and runs distribution
+// checks, as specified in Clause 9.2 of the TPC-C spec.
+type auditor struct {
+	newOrderTransactions uint64
+	newOrderRollbacks    uint64
+}
+
+// runChecks runs the audit checks and prints warnings to stdout for those that
+// fail.
+func (a *auditor) runChecks() {
+	type check struct {
+		name string
+		f    func(a *auditor) error
+	}
+	checks := []check{
+		{"9.2.2.5.1", check92251},
+	}
+	for _, check := range checks {
+		result := check.f(a)
+		if result != nil {
+			fmt.Println(errors.Wrapf(result, "WARN: Failed audit check %s", check.name))
+		}
+	}
+}
+
+func check92251(a *auditor) error {
+	// At least 0.9% and at most 1.1% of the New-Order transactions roll back as a
+	// result of an unused item number.
+	orders := atomic.LoadUint64(&a.newOrderTransactions)
+	if orders < 10000 {
+		// Not enough orders to be statistically significant.
+		return nil
+	}
+	rollbacks := atomic.LoadUint64(&a.newOrderRollbacks)
+	rollbackPct := 100 * float64(rollbacks) / float64(orders)
+	if rollbackPct < 0.9 || rollbackPct > 1.1 {
+		return errors.Errorf(
+			"new order rollback percent %.1f is not between allowed bounds [0.9, 1.1]", rollbackPct)
+	}
+	return nil
+}

--- a/tpcc/delivery.go
+++ b/tpcc/delivery.go
@@ -47,7 +47,7 @@ type delivery struct{}
 
 var _ tpccTx = newOrder{}
 
-func (del delivery) run(db *sql.DB, wID int) (interface{}, error) {
+func (del delivery) run(db *sql.DB, wID int, audit *auditor) (interface{}, error) {
 	oCarrierID := rand.Intn(10) + 1
 	olDeliveryD := time.Now()
 

--- a/tpcc/main.go
+++ b/tpcc/main.go
@@ -229,6 +229,7 @@ func main() {
 
 	start := time.Now()
 	errCh := make(chan error)
+	audit := auditor{}
 	var wg sync.WaitGroup
 	for i := range workers {
 		w := i % *warehouses
@@ -236,7 +237,7 @@ func main() {
 		// partitionTables().
 		p := (w * *partitions) / *warehouses
 		dbs := partitionDBs[p]
-		workers[i] = newWorker(i, w, dbs[w%len(dbs)], &wg)
+		workers[i] = newWorker(i, w, dbs[w%len(dbs)], &wg, &audit)
 	}
 
 	go func() {
@@ -384,6 +385,7 @@ func main() {
 					time.Duration(h.ValueAtQuantile(99)).Seconds()*1000,
 					time.Duration(h.ValueAtQuantile(100)).Seconds()*1000)
 			}
+			audit.runChecks()
 			return
 		}
 	}

--- a/tpcc/order_status.go
+++ b/tpcc/order_status.go
@@ -62,7 +62,7 @@ type orderStatus struct{}
 
 var _ tpccTx = orderStatus{}
 
-func (o orderStatus) run(db *sql.DB, wID int) (interface{}, error) {
+func (o orderStatus) run(db *sql.DB, wID int, a *auditor) (interface{}, error) {
 	d := orderStatusData{
 		dID: rand.Intn(9) + 1,
 	}

--- a/tpcc/payment.go
+++ b/tpcc/payment.go
@@ -77,7 +77,7 @@ type payment struct{}
 
 var _ tpccTx = payment{}
 
-func (p payment) run(db *sql.DB, wID int) (interface{}, error) {
+func (p payment) run(db *sql.DB, wID int, a *auditor) (interface{}, error) {
 	d := paymentData{
 		dID: rand.Intn(10) + 1,
 		// hAmount is randomly selected within [1.00..5000.00]

--- a/tpcc/stock_level.go
+++ b/tpcc/stock_level.go
@@ -50,7 +50,7 @@ type stockLevel struct{}
 
 var _ tpccTx = stockLevel{}
 
-func (s stockLevel) run(db *sql.DB, wID int) (interface{}, error) {
+func (s stockLevel) run(db *sql.DB, wID int, a *auditor) (interface{}, error) {
 	// 2.8.1.2: The threshold of minimum quantity in stock is selected at random
 	// within [10..20].
 	d := stockLevelData{


### PR DESCRIPTION
I added some basic auditing functionality to the TPC-C workload. This is
similar to the existing checks in checks.go, but rather than querying
the db it relies on statistics which are gathered as the workload runs.
Right now the audit checks are performed only when the workload exits,
but in the future we could also consider running them periodically as it
runs.

Refers #151