### PR TITLE
tpcc: fix random range of several events

### DIFF
--- a/tpcc/generate.go
+++ b/tpcc/generate.go
@@ -213,7 +213,7 @@ VALUES `
 					// 10% of the customer rows have bad credit.
 					// See section 4.3, under the CUSTOMER table population section.
 					credit := goodCredit
-					if rand.Intn(9) == 0 {
+					if rand.Intn(10) == 0 {
 						// Poor 10% :(
 						credit = badCredit
 					}

--- a/tpcc/order_status.go
+++ b/tpcc/order_status.go
@@ -64,7 +64,7 @@ var _ tpccTx = orderStatus{}
 
 func (o orderStatus) run(db *sql.DB, wID int, a *auditor) (interface{}, error) {
 	d := orderStatusData{
-		dID: rand.Intn(9) + 1,
+		dID: rand.Intn(10) + 1,
 	}
 
 	// 2.6.1.2: The customer is randomly selected 60% of the time by last name

--- a/tpcc/random.go
+++ b/tpcc/random.go
@@ -71,7 +71,7 @@ func randAString(min, max int) string {
 // containing the string "ORIGINAL" somewhere in the middle of the string.
 // See 4.3.3.1.
 func randOriginalString() string {
-	if rand.Intn(9) == 0 {
+	if rand.Intn(10) == 0 {
 		l := randInt(26, 50)
 		off := randInt(0, l-8)
 		return randAString(off, off) + originalString + randAString(l-off-8, l-off-8)

--- a/tpcc/stock_level.go
+++ b/tpcc/stock_level.go
@@ -55,7 +55,7 @@ func (s stockLevel) run(db *sql.DB, wID int, a *auditor) (interface{}, error) {
 	// within [10..20].
 	d := stockLevelData{
 		threshold: randInt(10, 20),
-		dID:       rand.Intn(9) + 1,
+		dID:       rand.Intn(10) + 1,
 	}
 
 	if err := crdb.ExecuteTx(


### PR DESCRIPTION
rand.Intn is exclusive on the right, not inclusive. This caused several
mistakes in implementation.

1. `11.11...%` of customers in the initial dataset have bad credit
instead of 10%. this causes the payment transaction to do slightly more
work - when customers have bad credit, some strings must be appended and
returned to the user.

2. the read-only orderStatus transaction was only selecting over 9
districts, instead of 10. this will slightly reduce contention when
fixed.

3. `11.11...%` of items have the string ORIGINAL in them instead of 10%.
this has no appreciable effect.

4. the read-only stockLevel transaction only selected over 9 districts,
instead of 10. this will slightly reduce contention when fixed.
```